### PR TITLE
fix: add debug logging to agent script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,31 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# We remove 'set -e' to ensure we can capture logs even on failure.
+set -uo pipefail
 
 echo "[agent] Tick started at $(date -u +%FT%TZ)"
+echo "[agent] Running the airdrop collection cycle with advanced logging..."
 
-echo "[agent] Running the airdrop collection cycle..."
-python3 -u advanced_airdrop_automation.py
+# Create a log file for this run
+LOG_FILE="run_$(date +%s).log"
+echo "--- Python Script Output ---" > $LOG_FILE
 
-echo "[agent] Tick finished successfully at $(date -u +%FT%TZ)"
+# Run the python script, redirecting all output (stdout and stderr) to the log file.
+# The script's exit code will be captured.
+python3 -u advanced_airdrop_automation.py &>> $LOG_FILE
+EXIT_CODE=$?
+
+# Print the entire log file to the GitHub Actions console
+echo ""
+echo "--- START OF SCRIPT LOG ---"
+cat $LOG_FILE
+echo "--- END OF SCRIPT LOG (Exit Code: $EXIT_CODE) ---"
+echo ""
+
+# Now, we check the exit code and exit the main script with it.
+# This will make the GitHub Actions step succeed or fail correctly.
+if [ $EXIT_CODE -ne 0 ]; then
+  echo "[agent] Python script failed with exit code $EXIT_CODE."
+  exit $EXIT_CODE
+else
+  echo "[agent] Tick finished successfully at $(date -u +%FT%TZ)"
+fi


### PR DESCRIPTION
Wraps the python execution in start.sh to capture all output to a log file. This log file is then printed to the console regardless of the script's exit code. This will make previously hidden errors visible in the GitHub Actions logs.